### PR TITLE
temporary workflow and workflow templates tested working.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,20 +5,22 @@ System test repo for system tests defined using  argo workflows.
 # Prerequisities
 1.) Install Argo Workflow
 
-2.) Install Argo CLI
-
-
 ## Install argo workflow
+
+The argo workflow is deployed by argocd, below are optional commands to install it manually.
+
 Create argo namespace
 
 `kubectl create namespace argo`
 
 Install the latest version of argo workflow
 
-`kubectl apply -n argo -f https://github.com/argoproj/argo-workflows/releases/download/v3.5.5/install.yaml`
+`kubectl apply -n argo -f https://github.com/argoproj/argo-workflows/releases/download/v3.5.6/install.yaml`
 
 
 ## Install argo cli
+Argo CLI is installed when the argo-workflow is installed above. No need to deploy it separately. Below commands are optional, showing how to deploy argo cli manually.
+
 Download the binary
 
 `curl -sLO https://github.com/argoproj/argo-workflows/releases/download/v3.5.5/argo-linux-amd64.gz`
@@ -47,6 +49,23 @@ Execute workflow defined in a yaml file
 
 `argo submit -n argo --watch <yaml file> --serviceaccount argo`
 
+## passing parameter into argo workflow from argo submit command
+
+`argo submit -n argo --watch <yaml file> -p <parametername>=<parametervalue> --serviceaccount argo`
+
+e.g.
+`argo submit -n argo --watch <yaml file> -p url="https://dev.eodatahub.org.uk" --serviceaccount argo`
+
+## reading parameters from a file
+
+`argo submit -n argo --watch <yaml file> --parameter-file <parameterfilename> --serviceaccount argo`
+
+e.g.
+`argo submit -n argo --watch <yaml file> --parameter-file urlfile.yaml --serviceaccount argo`
+
+where, the urlfile.yaml is
+`url: https://dev.eodatahub.org.uk`
+
 
 # Executing argo workflow using UI
 
@@ -61,3 +80,17 @@ Due to the self-signed certificate, you will receive a TLS error which you will 
 Click `+ Submit New Workflow` and then `Edit using full workflow options`
 
 You can find an example workflow already in the text field. Press `+ Create` to start the workflow.
+
+
+# WorkflowTemplates
+
+## Creating workflowtemplates
+
+`argo template create url-test-workflowtemplate.yaml -n argo`
+
+Create workflow which includes reference to workflowtemplate as usual 
+
+`argo submit -n argo --watch -p url="https://dev.eodatahub.org.uk/" url-up-and-running-workflow.yaml --serviceaccount=argo`
+
+
+

--- a/system-tests/url-test-workflowtemplate.yaml
+++ b/system-tests/url-test-workflowtemplate.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: url-test-workflowtemplate # argo template create url-test-workflowtemplate.yaml
+spec:
+  entrypoint: url-up-and-running 
+  templates:
+    - name: url-up-and-running
+      inputs:
+        parameters:
+        - name: url       # parameter declaration for => argo submit -n argo --watch -p url="https://dev.eodatahub.org.uk/" homepage-test.yaml --serviceaccount=argo
+      script:
+        image: nyurik/alpine-python3-requests
+        command: [python]
+        source: |
+          import requests
+
+          try:
+            r = requests.get("{{inputs.parameters.url}}")
+
+            if (r.status_code == 200):
+              criteria = "Success"
+            else:
+              criteria = "Failed - Http response is "
+
+            print("{} {}".format(criteria, r.status_code))
+
+          except requests.exceptions.RequestException as e:
+            raise SystemExit(e)
+            
+        resources: # limit the resources
+          limits:
+            memory: 32Mi
+            cpu: 100m

--- a/system-tests/url-up-and-running-workflow.yaml
+++ b/system-tests/url-up-and-running-workflow.yaml
@@ -1,0 +1,11 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: url-up-and-running-workflow-
+spec:
+  entrypoint: url-up-and-running
+  arguments:
+    parameters:
+      - name: url
+  workflowTemplateRef:
+    name: url-test-workflowtemplate


### PR DESCRIPTION
This PR is created to merge changes done with in the scope of https://telespazio-uk.atlassian.net/browse/EODHP-267

Argo workflow template (url-test-workflowtemplate) and a workflow (url-up-and-running-workflow) which references the workflowTemplate has been created and tested.

 

[argo-workflow-system-tests/system-tests/url-test-workflowtemplate.yaml at EODHP-267-argo-workflow-c-url-test-templates · UKEODHP/argo-workflow-system-tests (github.com)](https://github.com/UKEODHP/argo-workflow-system-tests/blob/EODHP-267-argo-workflow-c-url-test-templates/system-tests/url-test-workflowtemplate.yaml)

[argo-workflow-system-tests/system-tests/url-up-and-running-workflow.yaml at EODHP-267-argo-workflow-c-url-test-templates · UKEODHP/argo-workflow-system-tests (github.com)](https://github.com/UKEODHP/argo-workflow-system-tests/blob/EODHP-267-argo-workflow-c-url-test-templates/system-tests/url-up-and-running-workflow.yaml)

This update will require to pass url name separately from argo submit command line and one by one for each url (as defined in Readme.md). 


List of urls to be tested:

https://dev.eodatahub.org.uk
https://dev.eodatahub.org.uk/vs
https://dev.eodatahub.org.uk/apphub
https://dev.eodatahub.org.uk/ades
https://dev.eodatahub.org.uk/keycloak
https://pulsar.eodatahub.org.uk


Below are the commands used during the verification of the changes.
`argo template create url-test-workflowtemplate.yaml -n argo
`

`argo submit -n argo --watch -p url="https://dev.eodatahub.org.uk/" url-up-and-running-workflow.yaml --serviceaccount=argo
`

I will update the argoworkflow (in a separate story) to make it read the url names from a file and let the workflow read url names from it.