### PR TITLE
workflow template created and tested, homepagetest is parameterized w…

### DIFF
--- a/system-tests/homepage-test.yaml
+++ b/system-tests/homepage-test.yaml
@@ -6,14 +6,17 @@ spec:
   entrypoint: homepage-up-and-running 
   templates:
     - name: homepage-up-and-running
+      inputs:
+        parameters:
+        - name: url       # parameter declaration for => argo submit -n argo --watch -p url="https://dev.eodatahub.org.uk/" homepage-test.yaml --serviceaccount=argo
       script:
-        image: broadinstitute/python-requests:2.7
+        image: nyurik/alpine-python3-requests
         command: [python]
         source: |
           import requests
 
           try:
-            r = requests.get("https://dev.eodatahub.org.uk/")
+            r = requests.get("{{inputs.parameters.url}}")
 
             if (r.status_code == 200):
               criteria = "Success"

--- a/system-tests/url-test-workflowtemplate_multipleurlfromfile.yaml
+++ b/system-tests/url-test-workflowtemplate_multipleurlfromfile.yaml
@@ -1,0 +1,57 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: url-test-workflowtemplate # argo template create url-test-workflowtemplate.yaml
+spec:
+  entrypoint: url-up-and-running 
+  templates:
+    - name: url-up-and-running
+      inputs:
+        parameters:
+        - name: url       # parameter declaration for => argo submit -n argo --watch -p url="https://dev.eodatahub.org.uk/" homepage-test.yaml --serviceaccount=argo
+      script:
+        image: nyurik/alpine-python3-requests
+        command: [python]
+        source: |
+          import requests
+
+          try:
+            r = requests.get("{{inputs.parameters.url}}")
+
+            if (r.status_code == 200):
+              criteria = "Success"
+            else:
+              criteria = "Failed - Http response is "
+
+            print("{} {}".format(criteria, r.status_code))
+
+          except requests.exceptions.RequestException as e:
+            raise SystemExit(e)
+
+    - name: url-read-from-file
+      inputs:
+        parameters:
+        - name: urlpath       # parameter declaration for => argo submit -n argo --watch -p url="https://dev.eodatahub.org.uk/" homepage-test.yaml --serviceaccount=argo
+      script:
+        image: nyurik/alpine-python3-requests
+        command: [python]
+        source: |
+          import requests
+
+          try:
+            r = requests.get("{{inputs.parameters.url}}")
+
+            if (r.status_code == 200):
+              criteria = "Success"
+            else:
+              criteria = "Failed - Http response is "
+
+            print("{} {}".format(criteria, r.status_code))
+
+          except requests.exceptions.RequestException as e:
+            raise SystemExit(e)
+            
+        resources: # limit the resources
+          limits:
+            memory: 32Mi
+            cpu: 100m


### PR DESCRIPTION
Argo workflow template (url-test-workflowtemplate) and a workflow (url-up-and-running-workflow) which references the workflowTemplate has been created and tested.

 

url-test-workflowtemplate.yaml

url-up-and-running-workflow.yaml

 

This update will require to pass url name separately from argo submit command line and one by one for each url (as defined in Readme.md). 

`argo template create url-test-workflowtemplate.yaml -n argo
`
`argo submit -n argo --watch -p url="https://dev.eodatahub.org.uk/" url-up-and-running-workflow.yaml --serviceaccount=argo
`


I will update the argoworkflow (in a separate story) to make it read the url names from a file and let the workflow read url names from it.